### PR TITLE
fix: downgrade cryptography version to 45.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pyseventeentrack"
-version = "1.1.0"
+version = "1.1.1"
 description = "A Simple Python API for 17track.net"
 readme = "README.md"
 authors = ["Shai Ungar <shaiungar@gmail.com>"]
@@ -25,7 +25,7 @@ aiohttp = ">=3.9.5"
 attrs = ">=19.3"
 python = "^3.9.0"
 pytz = ">=2021.1"
-cryptography = ">=45.0.4"
+cryptography = ">=45.0.3"
 
 [tool.poetry.dev-dependencies]
 aresponses = "^3.0.0"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,7 +13,7 @@ charset-normalizer==3.3.2
 cleo==2.1.0
 coverage==7.5.4
 crashtest==0.4.1
-cryptography==45.0.4
+cryptography==45.0.3
 dill==0.3.8
 distlib==0.3.8
 dulwich==0.21.7


### PR DESCRIPTION
**Describe what the PR does:**

downgrade cryptography version to 45.0.3
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
