### PR TITLE
Use timezone information from the api package event.

### DIFF
--- a/pyseventeentrack/package.py
+++ b/pyseventeentrack/package.py
@@ -286,17 +286,22 @@ class Package:  # pylint: disable=too-few-public-methods,too-many-instance-attri
 
         if self.timestamp is not None:
             tz = timezone(self.tz)
-            try:
-                timestamp = tz.localize(
-                    datetime.strptime(self.timestamp, "%Y-%m-%d %H:%M")
-                )
-            except ValueError:
+            if isinstance(self.timestamp, datetime):
+                timestamp = self.timestamp
+                if timestamp.tzinfo is None:
+                    timestamp = tz.localize(timestamp)
+            else:
                 try:
                     timestamp = tz.localize(
-                        datetime.strptime(self.timestamp, "%Y-%m-%d %H:%M:%S")
+                        datetime.strptime(self.timestamp, "%Y-%m-%d %H:%M")
                     )
                 except ValueError:
-                    timestamp = datetime(1970, 1, 1, tzinfo=UTC)
+                    try:
+                        timestamp = tz.localize(
+                            datetime.strptime(self.timestamp, "%Y-%m-%d %H:%M:%S")
+                        )
+                    except ValueError:
+                        timestamp = datetime(1970, 1, 1, tzinfo=UTC)
 
             if self.tz != "UTC":
                 timestamp = timestamp.astimezone(UTC)

--- a/pyseventeentrack/profile.py
+++ b/pyseventeentrack/profile.py
@@ -80,13 +80,22 @@ class Profile:
             if last_event_raw:
                 event = json.loads(last_event_raw)
 
+            timestamp = event.get("a")
+            dd = event.get("dd")
+            if dd:
+                try:
+                    dt_str = f"{dd['d']}T{dd['t']}{dd['tz']}"
+                    timestamp = datetime.fromisoformat(dt_str)
+                except Exception:
+                    pass
+
             kwargs: dict = {
                 "id": package.get("FTrackInfoId"),
                 "destination_country": package.get("FSecondCountry", 0),
                 "friendly_name": package.get("FRemark"),
                 "info_text": event.get("z"),
                 "location": " ".join([event.get("c", ""), event.get("d", "")]).strip(),
-                "timestamp": event.get("a"),
+                "timestamp": timestamp,
                 "tz": tz,
                 "origin_country": package.get("FFirstCountry", 0),
                 "package_type": package.get("FTrackStateType", 0),


### PR DESCRIPTION
**Describe what the PR does:**
Reads and processes the timezone information from the /orderapi/call {method: GetTrackInfoList} API present in the `Json.[].FLastEvent.dd` property.

Also adds support for receiving `datetime` objects as value for `Package.timestamp`.

I did not add any new tests, let me know if simply duplicating the first four package entries from [tests/fixtures/packages_response.json](https://github.com/dimarobert/pyseventeentrack/blob/improve-timezone/tests/fixtures/packages_response.json) and adding the additional `dd` information would be enough of a test suite for the changes, or you want a completely separate test case (and fixture file).

**Does this fix a specific issue?**

Fixes #11
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
